### PR TITLE
Add clang++ to llvm.cmake for aarch64

### DIFF
--- a/toolchains/aarch64/llvm.cmake
+++ b/toolchains/aarch64/llvm.cmake
@@ -14,6 +14,11 @@ find_program(CMAKE_C_COMPILER
     DOC "Path to clang."
     REQUIRED)
 
+find_program(CMAKE_CXX_COMPILER
+    NAMES "clang++"
+    DOC "Path to clang++."
+    REQUIRED)
+
 set(CMAKE_ASM_COMPILER ${CMAKE_C_COMPILER})
 
 find_program(CMAKE_OBJCOPY


### PR DESCRIPTION
Hi,

When I try to build the project with llvm toolchain, cmake falls back to g++ as its cpp compiler. Although there are no cpp files in this project (right?), it does not matter in a normal build. But I was experimenting with some clang-specific compiler flags, and it caused the build process to fail on its early compiler checks. More specifically, cmake tries to compile a sample cpp program with g++ in combination with my clang flags (which are not supported by g++) and fails.

Therefore, I think it won't hurt if we introduce clang++ as `CMAKE_CXX_COMPILER`, as we already do in `toolchains/fake_host/llvm.cmake` file. :-)